### PR TITLE
added missing "::type" in BOOST_FUSION_ADAPT_ADT_C_BASE

### DIFF
--- a/include/boost/fusion/adapted/adt/detail/adapt_base.hpp
+++ b/include/boost/fusion/adapted/adt/detail/adapt_base.hpp
@@ -274,7 +274,7 @@
                     BOOST_FUSION_ADAPT_STRUCT_UNPACK_NAME(NAME_SEQ)             \
                   , I                                                           \
                   , is_const<Seq>::value                                        \
-                >                                                               \
+                >::type                                                         \
             type;                                                               \
                                                                                 \
             BOOST_CONSTEXPR BOOST_FUSION_GPU_ENABLED                            \


### PR DESCRIPTION
In access::struct_member::apply the typedef adt_attribute_proxy<...>... lacked a missing "::type".
ADT-adapted structs didn't work e.g. with fold